### PR TITLE
Replace the deprecated componentWillReceiveProps

### DIFF
--- a/libraries/SelectMultipleButton.js
+++ b/libraries/SelectMultipleButton.js
@@ -78,12 +78,13 @@ export default class SelectMultipleButton extends Component {
     })
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.selected !== nextProps.selected) {
-      this.setState({
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (prevState.selected !== nextProps.selected) {
+      return {
         selected: nextProps.selected
-      })
+      }
     }
+    return null;
   }
 
   render() {


### PR DESCRIPTION
In order to replace the deprecated componentWillReceiveProps (fixes #8 ), I removed the following. 
```
  componentWillReceiveProps(nextProps) {
    if (this.props.selected !== nextProps.selected) {
      this.setState({
        selected: nextProps.selected
      })
    }
  }
```

and added the following, instead. 
```
  static getDerivedStateFromProps(nextProps, prevState) {
    if (prevState.selected !== nextProps.selected) {
      return {
        selected: nextProps.selected
      }
    }
    return null;
  }
```